### PR TITLE
upgrade Smods and migrate probability API usages for Santa and Spinagogue

### DIFF
--- a/Cosmos.json
+++ b/Cosmos.json
@@ -10,8 +10,5 @@
 	"badge_colour": "DA70D6",
 	"badge_text_colour": "FFFFFF",
 	"version": "0.0.3",
-	"dependencies": [
-		"Steamodded (>=1.0.0~ALPHA-1228c)",
-		"Lovely (>=0.6)",
-	]
+	"dependencies": ["Steamodded (>=1.0.0~ALPHA-0771a)"]
 }

--- a/cards/santajoker.lua
+++ b/cards/santajoker.lua
@@ -19,11 +19,19 @@ SMODS.Joker {
     pos = { x = 0, y = 0 },
     cost = 6,
     loc_vars = function(self, info_queue, card)
+        local numerator, denominator = SMODS.get_probability_vars(card, 1, card.ability.extra.odds, 'santa')
         info_queue[#info_queue + 1] = G.P_TAGS.tag_coupon
-        return{vars = {G.GAME.probabilities.normal or 1, card.ability.extra.odds}}
+        return {
+            vars = {numerator, denominator}
+        }
     end,
     calculate = function(self, card, context)
-        if context.end_of_round and not context.individual and not context.repetition and (pseudorandom('santa')<= G.GAME.probabilities.normal/card.ability.extra.odds ) then
+        if context.end_of_round and not context.individual and not context.repetition then
+            local success = SMODS.pseudorandom_probability(card, 'santa', 1, card.ability.extra.odds, 'santa')
+            if not success then
+                return
+            end
+
             G.E_MANAGER:add_event(Event({
                 func = (function()
                     add_tag(Tag('tag_coupon'))

--- a/cards/spinagogue.lua
+++ b/cards/spinagogue.lua
@@ -14,14 +14,15 @@ SMODS.Joker {
     blueprint_compat = true,
     eternal_compat = true,
     perishable_compat = true,
-    config = { extra = { add_odds = 4 } },
+    config = { extra = { odds = 4 } },
     rarity = 3,
     atlas = "JJPack",
     pos = { x = 6, y = 0 },
     cost = 8,
     loc_vars = function(self, info_queue, card)
+        local numerator, denominator = SMODS.get_probability_vars(card, 1, card.ability.extra.odds, 'spinagogue')
         return {
-            vars = {G.GAME and G.GAME.probabilities.normal or 1, card.ability.extra.add_odds}
+            vars = {numerator, denominator}
         }
     end,
     calculate = function(self, card, context)
@@ -37,7 +38,8 @@ SMODS.Joker {
                             colour = G.C.RED
                         end
                     end
-                    if pseudorandom('jj_spinagogue_add') < G.GAME.probabilities.normal / card.ability.extra.add_odds then
+                    local success = SMODS.pseudorandom_probability(card, 'spinagogue', 1, card.ability.extra.odds, 'spinagogue')
+                    if success then
                         local edition = poll_edition('jj_spinagogue_edition', nil, true, true, { "e_foil", "e_holo", "e_polychrome" })
                         -- G.E_MANAGER:add_event(Event({
                         --     trigger = 'immediate',


### PR DESCRIPTION
I think these are the only two jokers affected by the new probability API. Just focusing on released content, so did not look at the in-development content.

some quick testing I did:
- text and behavior during basic gameplay
- text and behavior with Oops All 6s
- viewing text in non-game Collection

Note: For Spinagogue, I noticed that editions seem to be already applied before juice effects, though I think this is a pre-existing issue. 